### PR TITLE
Support NNS + ENS lookup of addresses

### DIFF
--- a/components/auction/bidRow.js
+++ b/components/auction/bidRow.js
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import BigNumber from "bignumber.js";
-import { useEns } from "../../hooks/useEns";
+import { useNnsEns } from "../../hooks/useNnsEns";
 import Davatar from "@davatar/react";
 import { TailSpin } from "../loader";
 import { useEffect } from "react";
@@ -8,7 +8,7 @@ import { useProvider } from "../../hooks/useProvider";
 
 const bidRow = ({ e, account, loading }) => {
   const p = useProvider();
-  const state = useEns(e.sender);
+  const state = useNnsEns(e.sender);
 
   const shortAddress = [e.sender.substr(0, 4), e.sender.substr(38, 4)].join(
     "..."

--- a/hooks/useNnsEns.js
+++ b/hooks/useNnsEns.js
@@ -1,0 +1,85 @@
+import { ethers, utils, BigNumber } from "ethers";
+import { useEffect, useRef, useReducer } from "react";
+import { useProvider } from "./useProvider";
+
+export const useNnsEns = (address) => {
+  const p = useProvider();
+  const cache = useRef({});
+
+  const shortAddress = [address.substr(0, 4), address.substr(38, 4)].join(
+    "..."
+  );
+
+  const initialState = {
+    loading: false,
+    data: "",
+  };
+
+  const [state, dispatch] = useReducer((state, action) => {
+    switch (action.type) {
+      case "FETCHING":
+        return { ...initialState, loading: true };
+      case "FETCHED":
+        return { ...initialState, loading: false, data: action.data };
+      default:
+        return state;
+    }
+  }, initialState);
+
+  useEffect(() => {
+    let cancelRequest = false;
+
+    const fn = async () => {
+      dispatch({ type: "FETCHING" });
+
+      if (cache.current[address]) {
+        dispatch({ type: "FETCHED", data: cache.current[address] });
+      } else {
+        try {
+          const name = await lookupAddress(p || ethers.getDefaultProvider(), address);
+          if (name) {
+            cache.current[address] = name;
+            if (cancelRequest) return;
+            dispatch({ type: "FETCHED", data: name });
+            return;
+          }
+
+          // cache address that doesn't have ens name
+          cache.current[address] = shortAddress;
+          dispatch({ type: "FETCHED", data: shortAddress });
+        } catch (error) {
+          if (cancelRequest) return;
+          dispatch({ type: "FETCHED", data: shortAddress });
+        }
+      }
+    };
+
+    fn();
+
+    return function cleanup() {
+      cancelRequest = true;
+    };
+  }, [address]);
+
+  return state;
+};
+
+async function lookupAddress(
+  library,
+  address
+) {
+  try {
+    const res = await library.call({
+      to: "0x5982ce3554b18a5cf02169049e81ec43bfb73961",
+      data: "0x55ea6c47000000000000000000000000" + address.substring(2),
+    });
+    const offset = BigNumber.from(utils.hexDataSlice(res, 0, 32)).toNumber();
+    const length = BigNumber.from(
+      utils.hexDataSlice(res, offset, offset + 32)
+    ).toNumber();
+    const data = utils.hexDataSlice(res, offset + 32, offset + 32 + length);
+    return utils.toUtf8String(data) || null;
+  } catch (e) {
+    return null;
+  }
+}


### PR DESCRIPTION
This PR adds support to NNS ([Nouns Naming Service](https://nns.xyz)) to lookup addresses using the recommended method described in [this demo](https://github.com/apbigcod/nns-resolver-demo#looking-up---domains-from-an-address-with-eth-fallback-with-resolver-contract) by the NNS team.

Here's an example of the output with 3 difference addresses:
- the first (`hello.eth`) that doesn't have an NNS (`.⌐◨-◨`) domain and therefore the `.eth` is shown
- the second that has no `.⌐◨-◨` nor `.eth` and therefore the address is shown
- the third that has a `.⌐◨-◨` domain and therefore the `.⌐◨-◨` name is shown

<img width="529" alt="Screenshot 2022-08-29 at 21 08 58" src="https://user-images.githubusercontent.com/105980313/187280975-bcb1fd9d-5770-4a4c-b2fc-af09d7b06f68.png">
